### PR TITLE
Quickfix: Restrict tinyrpc to version 0.9.4

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,7 +48,7 @@ chown vagrant:vagrant /home/vagrant/.tmux.conf
 echo '[ "$TERM" == "cygwin" ] && export TERM=cygwinB19' >> /home/vagrant/.profile
 
 # Install python packages
-sudo pip install ansiwrap termcolor terminaltables Pyro4 requests psutil ipaddr pyyaml
+sudo pip install ansiwrap termcolor terminaltables Pyro4 requests psutil ipaddr pyyaml tinyrpc==0.9.4
 
 # Remove unused directories
 sudo rm -rf \


### PR DESCRIPTION
tinyrpc 1.0.0 breaks python 2.7 support and only supports python3. 0.9.4
is the last version with python 2.7 support. Idealy this should be fixed
in the dependency list of ryu, but until that happens the problem can be
worked around by manually installing version 0.9.4.

Without this fix newly created virtual machines won't be able to run the
sdn controller